### PR TITLE
Readme examples: Set project name using COMPOSE_PROJECT_NAME

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine:3.2
 MAINTAINER Damien DUPORTAL <damien.duportal@gmail.com>
 MAINTAINER Christophe FURMANIAK <christophe.furmaniak@gmail.com>
 MAINTAINER Joseph PAGE <https://github.com/josephpage>
+MAINTAINER Ed Morley <https://github.com/edmorley>
 
 ENV DOCKER_COMPOSE_VERSION 1.2.0
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Just run it as a normal command, sharing the directory containing your docker-co
 ```bash
 $ docker run -v "$(pwd)":/app \
              -v /var/run/docker.sock:/var/run/docker.sock \
+             -e COMPOSE_PROJECT_NAME=$(basename "$(pwd)") \
              -ti --rm \
              dduportal/docker-compose:latest --help
 ```
@@ -27,6 +28,7 @@ In this example, we'll call docker-compose non-interactively (from a bash script
 ```bash
 $ docker run -v "$(pwd)":/app \
              -e DOCKER_HOST=tcp://10.0.2.15:2375 \
+             -e COMPOSE_PROJECT_NAME=$(basename "$(pwd)") \
              --rm \
              dduportal/docker-compose:latest up -d
 ```
@@ -36,6 +38,7 @@ On Windows when using the Boot2Docker provided MSYS shell, you should add ```/``
 ```bash
 $ docker run -v "/$(pwd)":/app \
              -v //var/run/docker.sock:/var/run/docker.sock \
+             -e COMPOSE_PROJECT_NAME=$(basename "/$(pwd)") \
              -ti --rm \
              dduportal/docker-compose:latest
 ```
@@ -47,7 +50,7 @@ Note: On Windows, if you are using MSYS **v2** or Cygwin (where ```pwd``` in the
 If you don't want to repeat yourself by typing all the options each time, just add an alias (interactive or in your .profile/.ashrc/etc :
 
 ```bash
-    echo 'alias docker-compose="docker run -v \"\$(pwd)\":/app -v /var/run/docker.sock:/var/run/docker.sock -ti --rm dduportal/docker-compose:latest"' \
+    echo 'alias docker-compose="docker run -v \"\$(pwd)\":/app -v /var/run/docker.sock:/var/run/docker.sock -e COMPOSE_PROJECT_NAME=\$(basename \"\$(pwd)\") -ti --rm dduportal/docker-compose:latest"' \
     >> ~/.ashrc
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ More information on the official Docker documentation : https://docs.docker.com/
 Just run it as a normal command, sharing the directory containing your docker-compose.yml file and the Docker Unix socket :
 
 ```bash
-$ docker run -v "$(pwd)":/app -v /var/run/docker.sock:/var/run/docker.sock -ti --rm dduportal/docker-compose:latest --help
+$ docker run -v "$(pwd)":/app \
+             -v /var/run/docker.sock:/var/run/docker.sock \
+             -ti --rm \
+             dduportal/docker-compose:latest --help
 ```
 
 **Customize the Docker socket**
@@ -22,13 +25,19 @@ When using another socket than the default Unix one (remote Docker engine use ca
 In this example, we'll call docker-compose non-interactively (from a bash script for example), given that the Docker daemon listen through a TCP connection at 10.0.2.15:2375 :
 
 ```bash
-$ docker run -v "$(pwd)":/app -e DOCKER_HOST=tcp://10.0.2.15:2375 --rm dduportal/docker-compose:latest up -d
+$ docker run -v "$(pwd)":/app \
+             -e DOCKER_HOST=tcp://10.0.2.15:2375 \
+             --rm \
+             dduportal/docker-compose:latest up -d
 ```
 
 On Windows when using the Boot2Docker provided MSYS shell, you should add ```/``` before each of the host paths passed to ```-v```, to help the path conversion [(courtesy of @joostfarla)](https://github.com/dduportal-dockerfiles/docker-compose/issues/1#issuecomment-99464292) :
 
-```
-> docker run -v "/$(pwd)":/app -v //var/run/docker.sock:/var/run/docker.sock -ti --rm dduportal/docker-compose:latest
+```bash
+$ docker run -v "/$(pwd)":/app \
+             -v //var/run/docker.sock:/var/run/docker.sock \
+             -ti --rm \
+             dduportal/docker-compose:latest
 ```
 
 Note: On Windows, if you are using MSYS **v2** or Cygwin (where ```pwd``` in the home directory returns /home/Foo, rather than /c/Users/Foo), you'll also need to replace ```$(pwd)``` with ```$(pwd | sed s_/home_/c/Users_)```, so the correct directory is mounted.
@@ -37,7 +46,10 @@ Note: On Windows, if you are using MSYS **v2** or Cygwin (where ```pwd``` in the
 
 If you don't want to repeat yourself by typing all the options each time, just add an alias (interactive or in your .profile/.ashrc/etc :
 
-    echo 'alias docker-compose="docker run -v \"\$(pwd)\":/app -v /var/run/docker.sock:/var/run/docker.sock -ti --rm dduportal/docker-compose:latest"' >> ~/.ashrc
+```bash
+    echo 'alias docker-compose="docker run -v \"\$(pwd)\":/app -v /var/run/docker.sock:/var/run/docker.sock -ti --rm dduportal/docker-compose:latest"' \
+    >> ~/.ashrc
+```
 
 **Customize image from your custom Dockerfile**
 
@@ -55,8 +67,10 @@ Note that ENTRYPOINT will be inherited.
 
 Run it now (without option while you provide them inside the image instead of at run time ) :
 
+```bash
     docker build -t you/docker-compose ./
     docker run -ti --rm you/docker-compose ps
+```
 
 ## Volumes : relative and absolute
 


### PR DESCRIPTION
- Split the example commands onto multiple lines.
  To help improve readability - and to avoid the scrollbars on the page. The echo alias command has been left mostly as-is, to avoid extra whitespace being added to the alias in .ashrc.
- Set COMPOSE_PROJECT_NAME in the examples.
  By default Docker compose uses the current directory name as the project name. The project name is used as a prefix for the image names. However when using Compose via this docker-compose image, the directory name inside the container is always "app", which isn't helpful as a project name. This can be overridden by setting COMPOSE_PROJECT_NAME in the environment.
