### PR TITLE
Update Docker Compose to 1.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Joseph PAGE <https://github.com/josephpage>
 MAINTAINER Ed Morley <https://github.com/edmorley>
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV COMPOSE_VERSION 1.3.0
+ENV COMPOSE_VERSION 1.3.1
 
 RUN apt-get update -q \
 	&& apt-get install -y -q --no-install-recommends curl ca-certificates \

--- a/tests/bats/test-bats-dockerimage.bats
+++ b/tests/bats/test-bats-dockerimage.bats
@@ -2,7 +2,7 @@
 
 @test "With no cmd/args, the image return docker-compose version" {
 	result="$(docker run ${DOCKER_IMAGE_NAME})"
-	[[ "$result" == *"docker-compose version: 1.3.0"* ]]
+	[[ "$result" == *"docker-compose version: 1.3.1"* ]]
 	echo "-$result-"
 }
 


### PR DESCRIPTION
The following bugs have been fixed in 1.3.1 :
- docker-compose build would always attempt to pull the base image before building.
- docker-compose help migrate-to-labels failed with an error.
- If no network mode was specified, Compose would set it to "bridge", rather than allowing the Docker daemon to use its configured default network mode.

Changelog : https://github.com/docker/compose/blob/1.3.1/CHANGES.md

Thanks @dduportal !
