### PR TITLE
Full end user test + moving to Docker APi v2

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 machine:
   services:
     - docker
+  pre:
+    - sudo curl -L -o /usr/bin/docker 'http://s3-external-1.amazonaws.com/circle-downloads/docker-1.6.2-circleci'; sudo chmod 0755 /usr/bin/docker; true
 dependencies:
   override:
     - make build

--- a/tests/bats/test-bats-dockerimage.bats
+++ b/tests/bats/test-bats-dockerimage.bats
@@ -6,25 +6,25 @@
 	echo "-$result-"
 }
 
-# @test "A Basic fig.yml must run a complete lifecycle" {
-# 	# Docker-ception !!!!
-# 	# Note the remount due to lxc not following volumes from with old versions of Docker
-# 	# in Circle Ci
-# 	docker run \
-# 		--volumes-from $(hostname) \
-# 		-v /var/run/docker.sock:/docker.sock \
-# 		-e DOCKER_HOST=unix:///docker.sock \
-# 		--workdir /app/tests/sample \
-# 		"${DOCKER_IMAGE_NAME}" build
+@test "A Basic fig.yml must run a complete lifecycle" {
+	# Docker-ception !!!!
+	# Note the remount due to lxc not following volumes from with old versions of Docker
+	# in Circle Ci
+	docker run \
+		--volumes-from $(hostname) \
+		-v /var/run/docker.sock:/docker.sock \
+		-e DOCKER_HOST=unix:///docker.sock \
+		--workdir /app/tests/sample \
+		"${DOCKER_IMAGE_NAME}" build
 
-# 	docker run \
-# 		--volumes-from $(hostname) \
-# 		-v /var/run/docker.sock:/docker.sock \
-# 		-e DOCKER_HOST=unix:///docker.sock \
-# 		--workdir /app/tests/sample \
-# 		"${DOCKER_IMAGE_NAME}" up -d
+	docker run \
+		--volumes-from $(hostname) \
+		-v /var/run/docker.sock:/docker.sock \
+		-e DOCKER_HOST=unix:///docker.sock \
+		--workdir /app/tests/sample \
+		"${DOCKER_IMAGE_NAME}" up -d
 
-# }
+}
 
 DEBIAN_VERSION=8.1
 @test "We use the debian linux version ${DEBIAN_VERSION}" {


### PR DESCRIPTION
This PR introduce :
- Using docker 1.6.2, built by circleci people after asking them help, so we use a Docker Engine with the v2 API !
- Re-introduce a end-to-end test for docker-compose (a complete lifecycle using a yml file)

No change inside the image, but it will be rebuilt on the master 
