### PR TITLE
Moving to compose 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Docker-compose Docker Image CHANGELOG
 
+## 2015-09-23
+* Update to [docker-compose 1.4.2](https://github.com/docker/compose/releases/tag/1.4.2)
+
 ## 2015-07-21
 * Update to [docker-compose 1.3.3](https://github.com/docker/compose/releases/tag/1.3.3) 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Joseph PAGE <https://github.com/josephpage>
 MAINTAINER Ed Morley <https://github.com/edmorley>
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV COMPOSE_VERSION 1.3.3
+ENV COMPOSE_VERSION 1.4.2
 
 RUN apt-get update -q \
 	&& apt-get install -y -q --no-install-recommends curl ca-certificates \

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   services:
     - docker
   pre:
-    - sudo curl -L -o /usr/bin/docker 'http://s3-external-1.amazonaws.com/circle-downloads/docker-1.6.2-circleci'; sudo chmod 0755 /usr/bin/docker; true
+    - sudo curl -L -o /usr/bin/docker 'http://s3-external-1.amazonaws.com/circle-downloads/docker-1.8.1-circleci'; sudo chmod 0755 /usr/bin/docker; true
 dependencies:
   override:
     - make build

--- a/tests/bats/test-bats-dockerimage.bats
+++ b/tests/bats/test-bats-dockerimage.bats
@@ -1,8 +1,9 @@
 #!/usr/bin/env bats
 
-@test "With no cmd/args, the image return docker-compose version" {
+COMPOSE_VERSION=1.4.2
+@test "With no cmd/args, the image return docker-compose version ${COMPOSE_VERSION}" {
 	result="$(docker run ${DOCKER_IMAGE_NAME})"
-	[[ "$result" == *"docker-compose version: 1.3.3"* ]]
+	[[ "$result" == *"docker-compose version: ${COMPOSE_VERSION}"* ]]
 	echo "-$result-"
 }
 


### PR DESCRIPTION
After this issue - https://github.com/dduportal-dockerfiles/docker-compose/issues/19 and the recent maintenance update, here is the PR for docker-compose 1.4.x (1.4.2 at the date of this comment :) )

Signed-off-by: Damien DUPORTAL damien.duportal@gmail.com
