### PR TITLE
Docker-compose 1.7.0 upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Joseph PAGE <https://github.com/josephpage>
 MAINTAINER Ed Morley <https://github.com/edmorley>
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV COMPOSE_VERSION 1.6.0
+ENV COMPOSE_VERSION 1.7.0
 
 RUN apt-get update -q \
 	&& apt-get install -y -q --no-install-recommends curl ca-certificates \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build test all
 
 DOCKER_IMAGE_NAME=dduportal/docker-compose
-COMPOSE_VERSION=1.6.0
+COMPOSE_VERSION=1.7.0
 
 all: build test
 


### PR DESCRIPTION
Upgrade docker compose from 1.6.0 to 1.7.0 to support new version 2
format.
